### PR TITLE
Added closing event

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ Toggle the "flash" class on the tab. `tab.unflash()` is an alias to `tab.flash(f
 
 Close the tab (and activate another tab if relevant). When `force` is set to `true` the tab will be closed even if it is not `closable`.
 
+#### Prevent a tab from closing after it was created
+
+Use the `closing` event and set the `closable` property to false
+
 ### Access webview element
 
 You can access the webview element and use its methods with through the `Tab.webview` attribute. See [webview documentation](http://electron.atom.io/docs/api/web-view-tag/#methods).
@@ -148,6 +152,7 @@ The following events are available:
 * `tab.on("flash", (tab) => { ... });`
 * `tab.on("unflash", (tab) => { ... });`
 * `tab.on("close", (tab) => { ... });`
+* `tab.on("closing", (tab) => { ... });`
 
 ## Drag and drop support
 

--- a/index.js
+++ b/index.js
@@ -225,6 +225,8 @@ class Tab extends EventEmitter {
     }
 
     close (force) {
+        this.emit("closing", this);
+        if (typeof force !== 'boolean') force = false;
         if (this.isClosed || (!this.closable && !force)) return;
         this.isClosed = true;
         let tabGroup = this.tabGroup;
@@ -294,13 +296,13 @@ const TabPrivate = {
 
     initWebview: function () {
         this.webview = document.createElement("webview");
-        
+
         const tabWebviewDidFinishLoadHandler = function (e) {
             this.emit("webview-ready", this);
         };
 
         this.webview.addEventListener("did-finish-load", tabWebviewDidFinishLoadHandler.bind(this), false);
-        
+
         this.webview.classList.add(this.tabGroup.options.viewClass);
         if (this.webviewAttributes) {
             let attrs = this.webviewAttributes;
@@ -308,7 +310,7 @@ const TabPrivate = {
                 this.webview.setAttribute(key, attrs[key]);
             }
         }
-        
+
         this.tabGroup.viewContainer.appendChild(this.webview);
     }
 };


### PR DESCRIPTION
My goal was to prevent a tab from closing when clicking the closing button.

I tried to use the closable property of the tab to make this if statement true (line 228):  
` if (this.isClosed || (!this.closable && !force)) return;`

But the force parameter is always true. If you console.log(force) you get a MouseEvent of type: "click".

I emitted a new event and checked if force was a boolean. 