### PR TITLE
Bug/force

### DIFF
--- a/index.js
+++ b/index.js
@@ -294,13 +294,13 @@ const TabPrivate = {
 
     initWebview: function () {
         this.webview = document.createElement("webview");
-
+        
         const tabWebviewDidFinishLoadHandler = function (e) {
             this.emit("webview-ready", this);
         };
 
         this.webview.addEventListener("did-finish-load", tabWebviewDidFinishLoadHandler.bind(this), false);
-
+        
         this.webview.classList.add(this.tabGroup.options.viewClass);
         if (this.webviewAttributes) {
             let attrs = this.webviewAttributes;
@@ -308,7 +308,7 @@ const TabPrivate = {
                 this.webview.setAttribute(key, attrs[key]);
             }
         }
-
+        
         this.tabGroup.viewContainer.appendChild(this.webview);
     }
 };

--- a/index.js
+++ b/index.js
@@ -268,7 +268,7 @@ const TabPrivate = {
             let button = container.appendChild(document.createElement("button"));
             button.classList.add(`${tabClass}-button-close`);
             button.innerHTML = this.tabGroup.options.closeButtonText;
-            button.addEventListener("click", this.close.bind(this), false);
+            button.addEventListener("click", this.close.bind(this, false), false);
         }
     },
 
@@ -294,13 +294,13 @@ const TabPrivate = {
 
     initWebview: function () {
         this.webview = document.createElement("webview");
-        
+
         const tabWebviewDidFinishLoadHandler = function (e) {
             this.emit("webview-ready", this);
         };
 
         this.webview.addEventListener("did-finish-load", tabWebviewDidFinishLoadHandler.bind(this), false);
-        
+
         this.webview.classList.add(this.tabGroup.options.viewClass);
         if (this.webviewAttributes) {
             let attrs = this.webviewAttributes;
@@ -308,7 +308,7 @@ const TabPrivate = {
                 this.webview.setAttribute(key, attrs[key]);
             }
         }
-        
+
         this.tabGroup.viewContainer.appendChild(this.webview);
     }
 };


### PR DESCRIPTION
Click event handler was called with an event object as first parameter. 
Using `close(force)` function as handler made the `force` parameter evaluated as the event. 
The event object is then evaluated as `true` in the if statement line 228.
The `close` function when called from the click handler is always considered as `close(true)`.

With my changes, the click handler calls `close` function with `false` so that `force` parameter in `close` is equals to `false`.

Now, a tab could become `closable` between the `initTabButtons` & the call to `close()`.

My goal with this pull request is to be able to interact with the user between the moment he clicks the closing button of a tab and the moment the tab actually closes. 
And prevent the last tab to close.

Displaying a modal like :
Unsaved file ! > Cancel / Save