### PR TITLE
fix issue #15 add duplicate tab when addTab with {active:true}

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,9 @@ class TabGroup extends EventEmitter {
         this.newTabId++;
         let tab = new Tab(this, id, args);
         this.tabs.push(tab);
+        if (args.active === true) {
+            tab.activate();
+        }
         this.emit("tab-added", tab, this);
         return tab;
     }
@@ -133,9 +136,6 @@ class Tab extends EventEmitter {
         TabPrivate.initWebview.bind(this)();
         if (args.visible !== false) {
             this.show();
-        }
-        if (args.active === true) {
-            this.activate();
         }
         if (typeof args.ready === "function") {
             args.ready(this);

--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ class TabGroup extends EventEmitter {
         this.newTabId++;
         let tab = new Tab(this, id, args);
         this.tabs.push(tab);
+        // Don't call tab.activate() before a tab is referenced in this.tabs
         if (args.active === true) {
             tab.activate();
         }


### PR DESCRIPTION
According to #15, tab duplication happens because
calling `activate()` in `let tab = new Tab(this, id, args);` calling stack
before `this.tabs.push(tab);` results in another tab reference in the tabs array.
A safe way is to call `activate()` separately after  `this.tabs.push(tab);`