### PR TITLE
Get tabs by position

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,27 @@ Retrieve an instance of `Tab` from this `id` (return `null` if not found).
 
 #### `tabGroup.getTabByPosition(position)`
 
-Retrieve an instance of `Tab` from this `position` (return `null` if not found).
+Retrieve an instance of `Tab` from this `position` (return `null` if not found). A negative value is an offset from the right.
+
+To get the tab in the leftmost position:
+
+```javascript
+tabGroup.getTabByPosition(1);
+```
+
+To get the tab in the rightmost position:
+
+```javascript
+tabGroup.getTabByPosition(-1);
+```
+
+> Note: Position 0 does not contain a tab.
+
+#### `tabGroup.getTabByRelPosition(position)`
+
+Retrieve an instance of `Tab` from this `position` relative to the active tab (return `null` if not found).
+`tabGroup.getNextTab()` is an alias to `tabGroup.getTabByRelPosition(1)`.
+`tabGroup.getPreviousTab()` is an alias to `tabGroup.getTabByRelPosition(-1)`.
 
 #### `tabGroup.getActiveTab()`
 
@@ -146,21 +166,7 @@ Get current tab icon URL / icon.
 
 #### `tab.setPosition(newPosition)`
 
-Move tab to the specified position. A negative value is an offset from the right.
-
-To move a tab to the leftmost position:
-
-```javascript
-tab.setPosition(1);
-```
-
-> Note: a position of 0 also moves the tab to the leftmost position
-
-To move a tab to the rightmost position:
-
-```javascript
-tab.setPosition(-1);
-```
+Move tab to the specified position. If `position` is 0 then `null` is returned and nothing happens. See [`tabGroup.getTabByPosition`](#tabgroupgettabbypositionposition) for information about positions.
 
 #### `tab.getPosition(fromRight)`
 

--- a/README.md
+++ b/README.md
@@ -86,9 +86,17 @@ Add a new tab to the tab group and returns a `Tab` instance.
 * `active` (default: `false`): set this to `true` if you want to activate the tab once it is loaded. Otherwise you will need to call `tab.activate()`.
 * `ready`: a callback function to call once the tab is ready. The `Tab` instance is passed as the only parameter.
 
-#### `tabGroup.getTab(id)`
+#### `tabGroup.getTab(id, idIsPosition)`
 
-Retrieve an instance of `Tab` from its `id` (return `null` if not found).
+If `idIsPosition` is true `id` is passed to `tabGroup.getTabByPosition`. Otherwise, `id` is passed to `tabGroup.getTabById`.
+
+#### `tabGroup.getTabById(id)`
+
+Retrieve an instance of `Tab` from this `id` (return `null` if not found).
+
+#### `tabGroup.getTabByPosition(position)`
+
+Retrieve an instance of `Tab` from this `position` (return `null` if not found).
 
 #### `tabGroup.getActiveTab()`
 

--- a/README.md
+++ b/README.md
@@ -86,11 +86,7 @@ Add a new tab to the tab group and returns a `Tab` instance.
 * `active` (default: `false`): set this to `true` if you want to activate the tab once it is loaded. Otherwise you will need to call `tab.activate()`.
 * `ready`: a callback function to call once the tab is ready. The `Tab` instance is passed as the only parameter.
 
-#### `tabGroup.getTab(id, idIsPosition)`
-
-If `idIsPosition` is true `id` is passed to `tabGroup.getTabByPosition`. Otherwise, `id` is passed to `tabGroup.getTabById`.
-
-#### `tabGroup.getTabById(id)`
+#### `tabGroup.getTab(id)`
 
 Retrieve an instance of `Tab` from this `id` (return `null` if not found).
 

--- a/index.js
+++ b/index.js
@@ -67,15 +67,7 @@ class TabGroup extends EventEmitter {
         return tab;
     }
 
-    getTab (id, idIsPosition) {
-        if (idIsPosition !== true) {
-            return this.getTabById(id);
-        } else {
-            return this.getTabByPosition(id);
-        }
-    }
-
-    getTabById (id) {
+    getTab (id) {
         for (let i in this.tabs) {
             if (this.tabs[i].id === id) {
                 return this.tabs[i];

--- a/index.js
+++ b/index.js
@@ -244,7 +244,7 @@ class Tab extends EventEmitter {
     }
 
     setPosition (newPosition) {
-        if (newPosition === 0) {
+        if (newPosition === 0 || newPosition === undefined) {
             return null;
         }
         let tabContainer = this.tabGroup.tabContainer;

--- a/index.js
+++ b/index.js
@@ -236,9 +236,6 @@ class Tab extends EventEmitter {
     }
 
     setPosition (newPosition) {
-        if (newPosition === 0 || newPosition === undefined) {
-            return null;
-        }
         let tabContainer = this.tabGroup.tabContainer;
         let tabs = tabContainer.children;
         let oldPosition = this.getPosition() - 1;

--- a/index.js
+++ b/index.js
@@ -67,9 +67,30 @@ class TabGroup extends EventEmitter {
         return tab;
     }
 
-    getTab (id) {
+    getTab (id, idIsPosition) {
+        if (idIsPosition !== true) {
+            return this.getTabById(id);
+        } else {
+            return this.getTabByPosition(id);
+        }
+    }
+
+    getTabById (id) {
         for (let i in this.tabs) {
             if (this.tabs[i].id === id) {
+                return this.tabs[i];
+            }
+        }
+        return null;
+    }
+
+    getTabByPosition (position) {
+        let fromRight = position < 0;
+        if (position === 0) {
+            position = 1;
+        }
+        for (let i in this.tabs) {
+            if (this.tabs[i].getPosition(fromRight) === position) {
                 return this.tabs[i];
             }
         }
@@ -212,7 +233,7 @@ class Tab extends EventEmitter {
     setPosition (newPosition) {
         let tabContainer = this.tabGroup.tabContainer;
         let tabs = tabContainer.children;
-        let oldPosition = this.getPosition();
+        let oldPosition = this.getPosition() - 1;
 
         if (newPosition < 0) {
             newPosition += tabContainer.childElementCount;
@@ -247,8 +268,8 @@ class Tab extends EventEmitter {
             position -= this.tabGroup.tabContainer.childElementCount;
         }
 
-        if (position === 0) {
-            position = 1;
+        if (position >= 0) {
+            position++;
         }
 
         return position;

--- a/index.js
+++ b/index.js
@@ -86,15 +86,28 @@ class TabGroup extends EventEmitter {
 
     getTabByPosition (position) {
         let fromRight = position < 0;
-        if (position === 0) {
-            position = 1;
-        }
         for (let i in this.tabs) {
             if (this.tabs[i].getPosition(fromRight) === position) {
                 return this.tabs[i];
             }
         }
         return null;
+    }
+
+    getTabByRelPosition (position) {
+        position = this.getActiveTab().getPosition() + position;
+        if (position <= 0) {
+            return null;
+        }
+        return this.getTabByPosition(position);
+    }
+
+    getNextTab () {
+        return this.getTabByRelPosition(1);
+    }
+
+    getPreviousTab () {
+        return this.getTabByRelPosition(-1);
     }
 
     getTabs () {
@@ -231,6 +244,9 @@ class Tab extends EventEmitter {
     }
 
     setPosition (newPosition) {
+        if (newPosition === 0) {
+            return null;
+        }
         let tabContainer = this.tabGroup.tabContainer;
         let tabs = tabContainer.children;
         let oldPosition = this.getPosition() - 1;


### PR DESCRIPTION
Make it possible to get tabs by their position and their position relative to the active tab. `TabGroup.getTab` can be used to get tabs by id or postion, but defaults to id in order to be consistent with existing functionality.