### PR TITLE
Add 'declare' modifier to top-level elements in Typescript declarations file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import {EventEmitter} from 'events';
 import {WebviewTag} from 'electron';
 
-class ElectronTabs extends EventEmitter {
+declare class ElectronTabs extends EventEmitter {
   constructor(options?: ElectronTabs.TabGroupOptions);
   addTab(options?: ElectronTabs.TabOptions): ElectronTabs.Tab;
   getTab(id: string): ElectronTabs.Tab | null;
@@ -16,7 +16,7 @@ class ElectronTabs extends EventEmitter {
   tabContainer: HTMLElement;
 }
 
-namespace ElectronTabs {
+declare namespace ElectronTabs {
   export interface TabGroupOptions {
     tabContainerSelector?: string;
     buttonsContainerSelector?: string;


### PR DESCRIPTION
`declare` has been required for all top-level non-interface elements (i.e. namespace, class) in a declaration `.d.ts` file since Typescript 0.9 (released in 2013). This updates the declarations file to do just that, allowing it to compile with modern Typescript versions.

Stackoverflow post for reference: https://stackoverflow.com/questions/17635033/error-ts1046-declare-modifier-required-for-top-level-element/17635034