### PR TITLE
Added id to interface Tab

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -43,6 +43,7 @@ declare namespace ElectronTabs {
   }
 
   export interface Tab extends EventEmitter {
+    id: number;
     setTitle(title: string): void;
     getTitle(): string;
     setBadge(badge: string): void;


### PR DESCRIPTION
Fixes TS2339: Property 'id' does not exist on type 'Tab'.