### PR TITLE
fixes #76 add options nodeIntegration,webviewTag into the demo for over electron-5.0

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -6,7 +6,12 @@ app.setName('electron-tabs-demo');
 
 app.on('ready', function () {
 
-    const mainWindow = new electron.BrowserWindow();
+    const mainWindow = new electron.BrowserWindow({
+      webPreferences: {
+        nodeIntegration: true,
+        webviewTag: true
+      }
+    });
     mainWindow.loadURL('file://' + __dirname + '/electron-tabs.html');
     mainWindow.on('ready-to-show', function () {
         mainWindow.show();


### PR DESCRIPTION
Hi,

I noticed that your library does not run on electron-6.0.10. But we can fix it. The new electron is more secure, so we can move it by specifying an option to loosen it.

before:

![スクリーンショット 2019-09-21 22 53 11](https://user-images.githubusercontent.com/759165/65374378-50465c80-dcc4-11e9-8076-b4eea44bf4cf.png)

after:

![スクリーンショット 2019-09-21 23 05 49](https://user-images.githubusercontent.com/759165/65374383-56d4d400-dcc4-11e9-9b6c-ff614c597a2f.png)
