### PR TITLE
fixes #59 - hide webviews using visibility style instead of zero size (macOS also tested)

### DIFF
--- a/electron-tabs.css
+++ b/electron-tabs.css
@@ -129,5 +129,5 @@
 }
 
 .etab-view {
-
+    position: relative;
 }

--- a/index.js
+++ b/index.js
@@ -8,16 +8,17 @@ if (!document) {
 (function () {
     const styles = `
         webview {
-            width: 0px;
-            height: 0px;
-        }
-        webview.visible {
             width: 100%;
             height: 100%;
             top: 0;
             right: 0;
             bottom: 0;
             left: 0;
+            position: absolute;
+            visibility: hidden;
+        }
+        webview.visible {
+            visibility: visible;
         }
     `;
     let styleTag = document.createElement("style");


### PR DESCRIPTION
This PR is almost same as https://github.com/brrd/electron-tabs/pull/60 by maxosprojects except it has CSS modification in .etabs-views.

This PR is response to https://github.com/brrd/electron-tabs/pull/60#issuecomment-542126373
