### PR TITLE
Add the ability to cancel a close from the closing event

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,9 +183,20 @@ Toggle the "visible" class on the tab. `tab.hide()` is an alias to `tab.show(fal
 
 Toggle the "flash" class on the tab. `tab.unflash()` is an alias to `tab.flash(false)`.
 
+#### `tab.cancelClose()`
+
+Sets allowClose to false to cancel the next close attempt, useful for cancelling a close attempt from the closing event:
+```javascript
+tab.on("closing", function(tab, force) {
+    if (force || !confirm('Are you sure you wish to close this tab?')) {
+        tab.cancelClose();
+    }
+});
+```
+
 #### `tab.close(force)`
 
-Close the tab (and activate another tab if relevant). When `force` is set to `true` the tab will be closed even if it is not `closable`.
+Close the tab (and activate another tab if relevant). When `force` is set to `true` the tab will be closed even if it is not `closable` or `allowClose` was set to false.
 
 ### Access webview element
 
@@ -213,7 +224,7 @@ The following events are available:
 * `tab.on("flash", (tab) => { ... });`
 * `tab.on("unflash", (tab) => { ... });`
 * `tab.on("close", (tab) => { ... });`
-* `tab.on("closing", (tab) => { ... });`
+* `tab.on("closing", (tab, force) => { ... });`
 
 ## Drag and drop support
 

--- a/index.js
+++ b/index.js
@@ -168,6 +168,7 @@ class Tab extends EventEmitter {
         this.webviewAttributes = args.webviewAttributes || {};
         this.webviewAttributes.src = args.src;
         this.tabElements = {};
+        this.allowClose = true;
         TabPrivate.initTab.bind(this)();
         TabPrivate.initWebview.bind(this)();
         if (args.visible !== false) {
@@ -328,8 +329,17 @@ class Tab extends EventEmitter {
         return this.flash(false);
     }
 
+    cancelClose () {
+        this.allowClose = false;
+    }
+
     close (force) {
-        this.emit("closing", this);
+        this.emit("closing", this, force);
+        if (!this.allowClose && !force) {
+            this.allowClose = !this.allowClose;
+            return;
+        }
+
         if (this.isClosed || (!this.closable && !force)) return;
         this.isClosed = true;
         let tabGroup = this.tabGroup;


### PR DESCRIPTION
These changes allow us to cancel a closing event, as demonstrated in the example added to the README

May also fix the comment on issue #53