### PR TITLE
Update demo page to open a new tab to google

### DIFF
--- a/demo/electron-tabs.html
+++ b/demo/electron-tabs.html
@@ -19,13 +19,15 @@
 
     let tabGroup = new TabGroup({
         newTab: {
-            title: 'New Tab'
+            title: "Google",
+            src: "http://google.com",
+            active: true
         }
     });
 
     tabGroup.addTab({
-        title: 'Google',
-        src: 'http://google.com',
+        title: "Google",
+        src: "http://google.com"
     });
 
     tabGroup.addTab({


### PR DESCRIPTION
Currently the tab opens a blank webview that doesn't show off the library very well