### PR TITLE
Update CSS to fix issue with overlapping webviews

### DIFF
--- a/electron-tabs.css
+++ b/electron-tabs.css
@@ -128,6 +128,22 @@
     height: calc(100vh - 33px);
 }
 
-.etab-view {
-    position: relative;
+.etabs-views webview {
+    width: 0;
+    height: 0;
+    top: 32px;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    position: absolute;
+    visibility: hidden;
+}
+
+.etabs-views webview.visible {
+    width: 100%;
+    height: calc(100vh - 32px);
+    visibility: visible;
+}
+
+.etabs-view {
 }

--- a/index.js
+++ b/index.js
@@ -4,28 +4,6 @@ if (!document) {
     throw Error("electron-tabs module must be called in renderer process");
 }
 
-// Inject styles
-(function () {
-    const styles = `
-        webview {
-            width: 100%;
-            height: 100%;
-            top: 0;
-            right: 0;
-            bottom: 0;
-            left: 0;
-            position: absolute;
-            visibility: hidden;
-        }
-        webview.visible {
-            visibility: visible;
-        }
-    `;
-    let styleTag = document.createElement("style");
-    styleTag.innerHTML = styles;
-    document.getElementsByTagName("head")[0].appendChild(styleTag);
-})();
-
 class TabGroup extends EventEmitter {
     constructor (args = {}) {
         super();
@@ -200,9 +178,9 @@ class Tab extends EventEmitter {
 
         if (badge) {
             span.innerHTML = badge;
-            span.classList.remove('hidden');
+            span.classList.remove("hidden");
         } else {
-            span.classList.add('hidden');
+            span.classList.add("hidden");
         }
 
         this.emit("badge-changed", badge, this);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-tabs",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Simple tabs for Electron applications",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This also fixes an issue with the webview selector being used and potentially causing conflicts with other plugins/implementations of webviews

Updated version to 12 as these css changes may break implementations that rely on the injected styles