### PR TITLE
Fix TypeScript compile error with Electron

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,4 @@
 import {EventEmitter} from 'events';
-import {WebviewTag} from 'electron';
 
 declare class ElectronTabs extends EventEmitter {
   constructor(options?: ElectronTabs.TabGroupOptions);
@@ -59,7 +58,7 @@ declare namespace ElectronTabs {
     flash(shown?: boolean): void;
     unflash(): void;
     close(force?: boolean): void;
-    webview: WebviewTag;
+    webview: Electron.WebviewTag;
   }
 }
 


### PR DESCRIPTION
`WebviewTag` is no longer defined in `electron` module, fix for 
```
node_modules/electron-tabs/index.d.ts:2:9 - error TS2305: Module '"electron"' has no exported member 'WebviewTag'.

2 import {WebviewTag} from 'electron';
```