### PR TITLE
Fix issue with hidden second line of tabs When there are two lines

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -53,7 +53,6 @@ webview.visible {
   font-size: var(--tab-font-size);
   display: none;
   width: 100%;
-  height: 32px;
   cursor: default;
   -webkit-user-select: none;
   user-select: none;
@@ -65,6 +64,7 @@ webview.visible {
 
 .tabs {
   height: 100%;
+  z-index: 9999;
 }
 
 .tab {


### PR DESCRIPTION
![electron-tabs](https://user-images.githubusercontent.com/5453263/232053998-ed5bf316-8bba-4f2b-a87a-632076f3d5b2.gif)

When there are multiple lines of tabs, the second line is not visible.Because the grandfather tag of the tabs has a fixed height of 32px, the second line and onwards are hidden when there are multiple rows. Removing the fixed height and allowing the height to adapt automatically can fix this issue. Additionally, if the z-index of the content area of the web view is too high, the tabs may not be visible.

This issue can be fixed by following:  #128 
@da201501245