### PR TITLE
fixed getTabByRelPosition

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -228,7 +228,7 @@ class TabGroup extends HTMLElement {
 
   getTabByRelPosition(position: number) {
     position = this.getActiveTab().getPosition() + position;
-    if (position <= 0) {
+    if (position < 0) {
       return null;
     }
     return this.getTabByPosition(position);


### PR DESCRIPTION
Currently, it's set at <= 0, which means going to previous tab from 2nd tab will result in an error, as it returns null. 

Changing it to < 0 fixes this issue.

Please see recent bug report in issues page.